### PR TITLE
corrected docker image typo for seekret

### DIFF
--- a/seekret/README.md
+++ b/seekret/README.md
@@ -22,7 +22,7 @@ workflow "Scan for secrets" {
 }
 
 action "Seekret" {
-  uses = "docker://cdssnc/seekret-github-action"
+  uses = "docker://cdssnc/seekret"
 }
 
 ```


### PR DESCRIPTION
There is a docker image for:
https://hub.docker.com/r/cdssnc/seekret
but not for:
https://hub.docker.com/r/cdssnc/seekret-github-action