### PR TITLE
change output of a11y-multiple-page-checker

### DIFF
--- a/a11y-multiple-page-checker/github-action/src/payloadHandler.js
+++ b/a11y-multiple-page-checker/github-action/src/payloadHandler.js
@@ -47,13 +47,25 @@ export const handle = async path => {
     results.map(result => {
       let data = result.data;
       if (data && data.violations && data.violations.length >= 1) {
-        console.log(
-          "Violations on page: /" + result.page + ": " + data.violations.length
-        );
+        console.log("\n/" + result.page + ": " + data.violations.length);
         data.violations.forEach(v => {
-          console.log("- " + JSON.stringify(v));
+          const json = JSON.stringify(v.nodes, null, 2);
+          let html;
+          try {
+            html = /"html": "(.*)",\n/.exec(json)[1];
+          } catch {
+            html = "html unknown";
+          }
+          console.log(`-- ${v.impact}: ${v.help}`);
+          console.log(`   ${v.helpUrl}`);
+          console.log(`   ${html}`);
         });
         issues.push(data.violations);
+      } else if (data.errorMessage) {
+        // response errored on the server side
+        console.log("\n/" + result.page + ": ERROR");
+        console.log(data.error);
+        issues.push(data.error);
       }
     });
 


### PR DESCRIPTION
changes what the `a11y-multiple-page-checker` scanner outputs for violations. Basically just output lines such as:
```
/p2/whathappened: 1
-- serious: Elements must have sufficient color contrast
   https://dequeuniversity.com/rules/axe/3.3/color-contrast?application=axe-puppeteer
   html: <span class=\"css-1rdyqc3 e1fxharu0\">Tell us about it in your own words.</span>

/p2/scammerdetails: 2
-- serious: Elements must have sufficient color contrast
   https://dequeuniversity.com/rules/axe/3.3/color-contrast?application=axe-puppeteer
   html: <span class=\"css-1rdyqc3 e1fxharu0\">Remember to include any email addresses, phone numbers, or website links</span>
-- moderate: Heading levels should only increase by one
   https://dequeuniversity.com/rules/axe/3.3/heading-order?application=axe-puppeteer
   html: <h3 class=\"css-1evt1v8 eoh9q0q0\">0 files attached</h3>
```